### PR TITLE
Rejuvenate log levels

### DIFF
--- a/java/client/src/org/openqa/selenium/devtools/Connection.java
+++ b/java/client/src/org/openqa/selenium/devtools/Connection.java
@@ -80,7 +80,7 @@ public class Connection implements Closeable {
       serialized.put("sessionId", sessionId);
     }
 
-    LOG.info(JSON.toJson(serialized.build()));
+    LOG.finest(JSON.toJson(serialized.build()));
     socket.sendText(JSON.toJson(serialized.build()));
 
     if (!command.getSendsResponse() ) {

--- a/java/client/test/org/openqa/selenium/build/BazelBuild.java
+++ b/java/client/test/org/openqa/selenium/build/BazelBuild.java
@@ -40,7 +40,7 @@ public class BazelBuild {
     if (target == null || "".equals(target)) {
       throw new IllegalStateException("No targets specified");
     }
-    log.info("\nBuilding " + target + " ...");
+    log.finest("\nBuilding " + target + " ...");
 
     ImmutableList.Builder<String> builder = ImmutableList.builder();
     builder.add("bazel", "build", target);

--- a/java/client/test/org/openqa/selenium/testing/drivers/TestEdgeDriver.java
+++ b/java/client/test/org/openqa/selenium/testing/drivers/TestEdgeDriver.java
@@ -76,7 +76,7 @@ public class TestEdgeDriver extends RemoteWebDriver implements WebStorage, Locat
                 .findFirst().orElseThrow(WebDriverException::new);
 
         service = (EdgeDriverService) builder.withVerbose(true).withLogFile(logFile.toFile()).build();
-        LOG.info("edgedriver will log to " + logFile);
+        LOG.fine("edgedriver will log to " + logFile);
         service.start();
         Runtime.getRuntime().addShutdownHook(new Thread(() -> service.stop()));
       }

--- a/java/server/src/com/thoughtworks/selenium/webdriven/WebDriverBackedSeleniumHandler.java
+++ b/java/server/src/com/thoughtworks/selenium/webdriven/WebDriverBackedSeleniumHandler.java
@@ -110,7 +110,7 @@ public class WebDriverBackedSeleniumHandler implements Routable {
     StringBuilder printableArgs = new StringBuilder("[");
     Joiner.on(", ").appendTo(printableArgs, args);
     printableArgs.append("]");
-    LOG.info(String.format("Command request: %s%s on session %s", cmd, printableArgs, sessionId));
+    LOG.finest(String.format("Command request: %s%s on session %s", cmd, printableArgs, sessionId));
 
     if ("getNewBrowserSession".equals(cmd)) {
       // Figure out what to do. If the first arg is "*webdriver", check for a session id and use

--- a/java/server/src/org/openqa/selenium/docker/Container.java
+++ b/java/server/src/org/openqa/selenium/docker/Container.java
@@ -58,7 +58,7 @@ public class Container {
   public void stop(Duration timeout) {
     Objects.requireNonNull(timeout);
 
-    LOG.info("Stopping " + getId());
+    LOG.warning("Stopping " + getId());
 
     String seconds = String.valueOf(timeout.toMillis() / 1000);
 

--- a/java/server/src/org/openqa/selenium/docker/Docker.java
+++ b/java/server/src/org/openqa/selenium/docker/Docker.java
@@ -93,7 +93,7 @@ public class Docker {
       throw new WebDriverException("Unable to pull container: " + name);
     }
 
-    LOG.info(String.format("Pull of %s:%s complete", name, tag));
+    LOG.fine(String.format("Pull of %s:%s complete", name, tag));
 
     return findImage(new ImageNamePredicate(name, tag))
         .orElseThrow(() -> new DockerException(

--- a/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
+++ b/java/server/src/org/openqa/selenium/grid/node/config/NodeOptions.java
@@ -70,7 +70,7 @@ public class NodeOptions {
       Capabilities caps = info.getCanonicalCapabilities();
       builders.stream()
           .filter(builder -> builder.score(caps) > 0)
-          .peek(builder -> LOG.info(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
+          .peek(builder -> LOG.finest(String.format("Adding %s %d times", caps, info.getMaximumSimultaneousSessions())))
           .forEach(builder -> {
             DriverService.Builder freePortBuilder = builder.usingAnyFreePort();
 

--- a/java/server/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
+++ b/java/server/src/org/openqa/selenium/grid/node/httpd/NodeServer.java
@@ -140,7 +140,7 @@ public class NodeServer implements CliCommand {
           () -> {
             HealthCheck.Result check = node.getHealthCheck().check();
             if (!check.isAlive()) {
-              LOG.info("Node is not alive: " + check.getMessage());
+              LOG.severe("Node is not alive: " + check.getMessage());
               // Throw an exception to force another check sooner.
               throw new UnsupportedOperationException("Node cannot be registered");
             }

--- a/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
+++ b/java/server/src/org/openqa/selenium/remote/server/ActiveSessionFactory.java
@@ -172,10 +172,10 @@ public class ActiveSessionFactory implements SessionFactory {
 
   @Override
   public Optional<ActiveSession> apply(CreateSessionRequest sessionRequest) {
-    LOG.info("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
+    LOG.finest("Capabilities are: " + new Json().toJson(sessionRequest.getCapabilities()));
     return factories.stream()
         .filter(factory -> factory.test(sessionRequest.getCapabilities()))
-        .peek(factory -> LOG.info(String.format("Matched factory %s", factory)))
+        .peek(factory -> LOG.finest(String.format("Matched factory %s", factory)))
         .map(factory -> factory.apply(sessionRequest))
         .filter(Optional::isPresent)
         .map(Optional::get)

--- a/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
+++ b/java/server/src/org/openqa/selenium/remote/server/SeleniumServer.java
@@ -74,7 +74,7 @@ public class SeleniumServer extends JettyServer {
           getClass().getClassLoader())
           .asSubclass(Routable.class);
       Constructor<? extends Routable> constructor = rcHandler.getConstructor(ActiveSessions.class);
-      LOG.info("Bound legacy RC support");
+      LOG.finest("Bound legacy RC support");
       return constructor.newInstance(sessions);
     } catch (ReflectiveOperationException e) {
       // Do nothing.

--- a/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
+++ b/java/server/test/org/openqa/selenium/grid/distributor/DistributorTest.java
@@ -582,7 +582,7 @@ public class DistributorTest {
         );
 
         Session firefoxSession = distributor.newSession(createRequest(firefoxPayload)).getSession();
-        LOG.info(String.format("Firefox Session %d assigned to %s", i, chromeSession.getUri()));
+        LOG.finer(String.format("Firefox Session %d assigned to %s", i, chromeSession.getUri()));
 
         boolean inFirefoxNodes = firefoxNodes.stream().anyMatch(node -> node.getUri().equals(firefoxSession.getUri()));
         boolean inChromeNodes = chromeNodes.stream().anyMatch(node -> node.getUri().equals(chromeSession.getUri()));


### PR DESCRIPTION
We appreciate your previous feedback and it's very helpful. Here's a reissue of SeleniumHQ#7170 with a new version of our tool. It takes a long time, sorry for waiting. The tool made many fewer transformations, however, there were a few that we removed that you did not agree with in the original PR. Again, we'd appreciate any feedback and are willing to make further changes if you wish to incorporate our PR into your project.

Settings
---
We have several analysis settings. We can vary these settings and rerun if you desire. The settings we are using in this pull request are:

Treat CONFIG levels as a category and not a traditional level, i.e., our tool ignores these log levels.
Never lower the logging level of logging statements within catch blocks.
Never lower the logging level of logging statements within if statements.
Never lower the logging level of logging statements containing certain (important) keywords.
Never raise the logging level of logging statements without particular keywords in their messages.
Avoid log wrapping by disregarding logging statements contained in if statements mentioning log levels.
The greatest number of commits from HEAD evaluated: 1000.
The head at the time of analysis was: a49fb60


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)
